### PR TITLE
Add Mastodon plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ cd bitlbee-mastodon && \
 make && \
 make install && \
 # cleanup
-apt-get autoremove -y --purge autoconf automake gcc libtool make dpkg-dev mercurial && \
+apt-get autoremove -y --purge autoconf automake gcc libtool make dpkg-dev mercurial git && \
 apt-get clean && \
 rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /tmp/* && \
 cd && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
-FROM buildpack-deps:jessie-curl
+FROM buildpack-deps:stretch-curl
 MAINTAINER Michele Bologna <michele.bologna@gmail.com>
 
 ENV VERSION=3.5.1
 
-RUN apt-get update && apt-get install -y --no-install-recommends autoconf automake gettext gcc libtool make dpkg-dev libglib2.0-dev libotr5-dev libpurple-dev libgnutls28-dev libjson-glib-dev libprotobuf-c-dev protobuf-c-compiler mercurial libgcrypt20 libgcrypt20-dev libwebp-dev && \
+RUN apt-get update && apt-get install -y --no-install-recommends autoconf automake gettext gcc libtool make dpkg-dev libglib2.0-dev libotr5-dev libpurple-dev libgnutls28-dev libjson-glib-dev libprotobuf-c-dev protobuf-c-compiler mercurial libgcrypt20 libgcrypt20-dev libwebp-dev git && \
 cd && \
 curl -LO# https://get.bitlbee.org/src/bitlbee-$VERSION.tar.gz && \
 curl -LO# https://github.com/EionRobb/skype4pidgin/archive/1.4.tar.gz && \
 curl -LO# https://github.com/majn/telegram-purple/releases/download/v1.3.1/telegram-purple_1.3.1.orig.tar.gz && \
 curl -LO# https://github.com/jgeboski/bitlbee-facebook/archive/v1.1.2.tar.gz && \
 hg clone https://bitbucket.org/EionRobb/purple-hangouts/ && \
+git clone https://alexschroeder.ch/cgit/bitlbee-mastodon && \
 tar zxvf bitlbee-$VERSION.tar.gz && \
 cd bitlbee-$VERSION && \
 ./configure --jabber=1 --otr=1 --purple=1 && \
@@ -41,6 +42,14 @@ cd && \
 cd purple-hangouts && \
 make && \
 make install && \
+# install bitlbee-mastodon
+cd && \
+cd bitlbee-mastodon && \
+./autogen.sh && \
+./configure --prefix=/usr && \
+make && \
+make install && \
+# cleanup
 apt-get autoremove -y --purge autoconf automake gcc libtool make dpkg-dev mercurial && \
 apt-get clean && \
 rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /tmp/* && \
@@ -51,6 +60,7 @@ rm -fr v1.1.2.tar.gz bitlbee-facebook-* && \
 rm -fr purple-hangouts && \
 rm -fr telegram-purple_1.3.1.orig.tar.gz && \
 rm -fr telegram-purple && \
+rm -rf bitlbee-mastodon && \
 mkdir -p /var/lib/bitlbee && \
 chown -R daemon:daemon /var/lib/bitlbee* # dup: otherwise it won't be chown'ed when using volumes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.3"
+
+services:
+  app:
+    image: mbologna/docker-bitlbee
+    restart: always
+    ports:
+      - "6667:6667"
+    volumes:
+      - data:/var/lib/bitlbee
+
+volumes:
+  data:


### PR DESCRIPTION
As [Mastodon](https://joinmastodon.org/) gets some traction in the social media sphere right now I took the chance to add the Mastodon plugin to your Docker Bitlbee image. So now you are able to connect to Mastodon from your IRC client via Bitlbee.

I also bumped the Debian version to stretch (current stable, but this is an optional step). Also took the courtesy to add a docker-compose config.