### PR TITLE
Uses ForkDaemon instead of Daemon mode.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,4 +115,4 @@ VOLUME ["/var/lib/bitlbee"]
 USER bitlbee
 ENTRYPOINT ["/entrypoint.sh"]
 
-CMD ["/usr/local/sbin/bitlbee", "-D", "-n", "-v", "-u", "bitlbee"]
+CMD ["/usr/local/sbin/bitlbee", "-F", "-n", "-v", "-u", "bitlbee"]


### PR DESCRIPTION
Daemon mode can be more unstable due to the use of single process, and libpurple plugins now refuse to start in daemon mode.

Example with telegram-tdlib:
```
 telegram-tdlib - Login error: Daemon mode detected. Do *not* try to use libpurple in daemon mode! Please use inetd or ForkDaemon mode instead.
```

Using ForkDaemon is essentially the same, with one process per client, and fixes the issue.