### PR TITLE
Fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
 
 RUN tar zxvf bitlbee-"$BITLBEE_VERSION".tar.gz
 WORKDIR /bitlbee-"$BITLBEE_VERSION"
-ENV LDFLAGS "-lgcrypt"
+ENV LDFLAGS="-lgcrypt"
 RUN ./configure --verbose=1 --jabber=1 --otr=1 --purple=1 --strip=1 && \
     make -j"$(nproc)" && \
     make install && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
 
 RUN tar zxvf bitlbee-"$BITLBEE_VERSION".tar.gz
 WORKDIR /bitlbee-"$BITLBEE_VERSION"
+ENV LDFLAGS "-lgcrypt"
 RUN ./configure --verbose=1 --jabber=1 --otr=1 --purple=1 --strip=1 && \
     make -j"$(nproc)" && \
     make install && \


### PR DESCRIPTION
When building the image I ran into this error:

```
3.282 ld -r account.o bee.o bee_chat.o bee_ft.o bee_user.o nogaim.o purple/purple_mod.o jabber/jabber_mod.o twitter/twitter_mod.o -o protocols.o
3.287 make[1]: Leaving directory '/bitlbee-3.6/protocols'
3.288 * Linking bitlbee
3.288 gcc bitlbee.o dcc.o help.o ipc.o irc.o irc_im.o irc_cap.o irc_channel.o irc_commands.o irc_send.o irc_user.o irc_util.o nick.o otr.o query.o root_commands.o set.o storage.o storage_xml.o auth.o  unix.o conf.o log.o lib/lib.o protocols/protocols.o -o bitlbee -pie  -lm -Wl,--export-dynamic -lgmodule-2.0 -pthread -lglib-2.0 -lglib-2.0  -lgnutls   -lresolv -lotr   -lpurple -lglib-2.0 
3.309 /usr/bin/ld: protocols/protocols.o: in function `prplcb_xfer_new':
3.311 /bitlbee-3.6/protocols/purple/ft.c:111:(.text+0x40fc): warning: the use of `mktemp' is dangerous, better use `mkstemp' or `mkdtemp'
3.327 /usr/bin/ld: lib/lib.o: undefined reference to symbol 'gcry_cipher_setiv@@GCRYPT_1.6'
3.327 /usr/bin/ld: /lib/x86_64-linux-gnu/libgcrypt.so.20: error adding symbols: DSO missing from command line
3.328 collect2: error: ld returned 1 exit status
3.328 make: *** [Makefile:167: bitlbee] Error 1
------
Dockerfile:35
--------------------
  35 | >>> RUN ./configure --verbose=1 --jabber=1 --otr=1 --purple=1 --strip=1 && \
  36 | >>>     make -j"$(nproc)" && \
  37 | >>>     make install && \
  38 | >>>     make install-bin && \
  39 | >>>     make install-doc && \
  40 | >>>     make install-dev && \
  41 | >>>     make install-etc && \
  42 | >>>     make install-plugin-otr
  43 |     
--------------------
```

adding this link flag fixed it.