### PR TITLE
fix(entrypoint): wire mautrix-meta appservice registration into conduwuit

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -160,6 +160,9 @@ allow_federation = false
 allow_registration = true
 registration_token = "${REG_TOKEN}"
 
+# mautrix-meta appservice registration — lets the bridge authenticate with this homeserver
+app_service_files = ["${MAUTRIX_DIR}/registration.yaml"]
+
 log = "warn,conduwuit=info"
 EOF
 
@@ -175,6 +178,14 @@ EOF
     echo "║  (see README for full setup steps)                          ║"
     echo "╚══════════════════════════════════════════════════════════════╝"
     echo ""
+fi
+
+# ── Step 2b: migrate existing conduwuit.toml (add app_service_files if missing) ──
+# Existing volumes written before this fix lack the app_service_files key, causing
+# mautrix-meta to crash-loop with "as_token was not accepted". Patch it idempotently.
+if [ -f "${CONDUWUIT_DIR}/conduwuit.toml" ] && ! grep -q 'app_service_files' "${CONDUWUIT_DIR}/conduwuit.toml"; then
+    echo "[migrate] Adding missing app_service_files to conduwuit.toml..."
+    printf '\n# mautrix-meta appservice registration — lets the bridge authenticate with this homeserver\napp_service_files = ["%s/registration.yaml"]\n' "${MAUTRIX_DIR}" >> "${CONDUWUIT_DIR}/conduwuit.toml"
 fi
 
 # ── Step 3: TLS certificate + stunnel config ─────────────────────────────────


### PR DESCRIPTION
## Summary

- `conduwuit.toml` was generated without `app_service_files`, so mautrix-meta crashed on every container start with `FTL The as_token was not accepted` (exit code 16)
- The comment at the top of `entrypoint.sh` already stated it should generate "A conduwuit.toml referencing the registration file above" — the implementation just never did it

## Changes

- **New installs**: `app_service_files` is now included in the `conduwuit.toml` heredoc
- **Existing volumes**: a migration block (Step 2b) appends the key if it's absent — takes effect on the next container restart, no data loss

## Test plan

- [ ] Fresh container start: verify `conduwuit.toml` contains `app_service_files` and mautrix-meta reaches `RUNNING` state in supervisord
- [ ] Existing volume (pre-fix): verify migration block appends the key and mautrix-meta no longer crash-loops after restart
- [ ] Idempotency: running the migration block twice does not duplicate the key

🤖 Generated with [Claude Code](https://claude.com/claude-code)